### PR TITLE
Ensure ListStories closes response body each iteration

### DIFF
--- a/internal/sb/client.go
+++ b/internal/sb/client.go
@@ -113,15 +113,17 @@ func (c *Client) ListStories(ctx context.Context, opt ListStoriesOpts) ([]Story,
 			return nil, err
 		}
 
-		defer res.Body.Close()
 		if res.StatusCode != 200 {
+			res.Body.Close()
 			return nil, fmt.Errorf("stories.list status %s", res.Status)
 		}
 
 		var payload storiesResp
 		if err := json.NewDecoder(res.Body).Decode(&payload); err != nil {
+			res.Body.Close()
 			return nil, err
 		}
+		res.Body.Close()
 
 		all = append(all, payload.Stories...)
 


### PR DESCRIPTION
## Summary
- close Storyblok API response body immediately after decoding
- close response body on error paths in ListStories

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa235c2cd0832983c34e05f7e27a98