### PR TITLE
Add project guidelines and roadmap documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,11 @@
 # AGENTS
 
 ## Overview
+
 Welcome to **storyblok-sync**, a Go-based terminal UI (TUI) for synchronising Stories and Folders between two Storyblok spaces. The codebase follows a clean separation of concerns and uses Bubble Tea for the UI.
 
 ### Repository layout
+
 ```
 storyblok-sync/
 ├─ cmd/sbsync/            # application entry point
@@ -14,19 +16,23 @@ storyblok-sync/
 ├─ go.mod / go.sum
 └─ testdata/              # fixtures for tests
 ```
+
 Future packages (e.g. `internal/core/`, `infra/`, etc.) should follow the structure outlined in the project roadmap.
 
 ## Coding conventions
-- **Go version:** 1.25  
-- **Formatting:** run `go fmt` (uses tabs for indentation)  
-- **Imports:** standard library groups first, third‑party packages second, internal packages last.  
-- **Naming & comments:** use English for identifiers and comments; user-facing strings remain in German where appropriate.  
-- **Errors:** return errors explicitly; wrap with `fmt.Errorf("… %w", err)` when adding context.  
-- **Testing:** add tests for new behaviour, keep them small and deterministic. Place fixtures under `testdata/` when needed.  
-- **Commit messages:** imperative mood, short summary on first line (“Add scan command”).  
+
+- **Go version:** 1.25
+- **Formatting:** run `go fmt` (uses tabs for indentation)
+- **Imports:** standard library groups first, third‑party packages second, internal packages last.
+- **Naming & comments:** use English for identifiers and comments; user-facing strings remain in German where appropriate.
+- **Errors:** return errors explicitly; wrap with `fmt.Errorf("… %w", err)` when adding context.
+- **Testing:** add tests for new behaviour, keep them small and deterministic. Place fixtures under `testdata/` when needed.
+- **Commit messages:** imperative mood, short summary on first line. Use conventional commit prefixes without scope, eg: (“feat: add scan command”).
 
 ## Testing & checks
+
 Before committing:
+
 1. `go fmt ./...`
 2. `go vet ./...`
 3. `go test ./...`
@@ -34,6 +40,7 @@ Before committing:
 All commands must succeed or the failure should be explained in the PR.
 
 ## PR guidelines
+
 - Describe user-facing changes briefly.
 - Note any deviations from these guidelines.
 - Do not include secrets or tokens in commits or logs.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Storyblok Sync is a terminal user interface (TUI) that synchronises Stories and Folders between two Storyblok spaces. It allows users to scan source and target spaces, select content, preview collisions and apply changes.
 
 ## Features
+
 - Scan source and target spaces and list stories with metadata.
 - Mark individual stories or entire folders for synchronisation.
 - Fuzzy search over name, slug and path.
@@ -11,6 +12,7 @@ Storyblok Sync is a terminal user interface (TUI) that synchronises Stories and 
 - Rescan at any time to refresh space data.
 
 ## User Flow
+
 1. **Welcome/Auth** – enter a token or load it from `~/.sbrc`.
 2. **SpaceSelect** – choose source and target spaces.
 3. **Scanning** – fetch stories for both spaces.
@@ -22,18 +24,20 @@ Storyblok Sync is a terminal user interface (TUI) that synchronises Stories and 
 Interrupts: `r` to rescan, `q` to abort.
 
 ## Development Roadmap (v0)
-- **T1 – Config & Auth:** load/save token and optional space IDs via `~/.sbrc`.
-- **T2 – Storyblok Client:** HTTP client with retries, rate limiting and basic endpoints.
-- **T3 – SpaceSelect Screen:** select source/target spaces in the UI.
-- **T4 – Scan + List View:** scan both spaces and display a flat list of stories.
-- **T5 – Fuzzy Search:** filter stories by name, slug or path.
-- **T6 – Preflight Collisions:** detect path/slug collisions and let users skip or overwrite.
-- **T7 – Sync Executor:** apply create/update operations with progress and retry logic.
-- **T8 – Report & Rescan:** final summary and option to rescan or quit.
-- **T9 – Keybind Help:** context-sensitive shortcut overlay.
-- **T10 – Logging:** structured logging, no telemetry.
+
+- [x] **T1 – Config & Auth:** load/save token and optional space IDs via `~/.sbrc`.
+- [x] **T2 – Storyblok Client:** HTTP client with retries, rate limiting and basic endpoints.
+- [x] **T3 – SpaceSelect Screen:** select source/target spaces in the UI.
+- [x] **T4 – Scan + List View:** scan both spaces and display a flat list of stories.
+- [x] **T5 – Fuzzy Search:** filter stories by name, slug or path.
+- [ ] **T6 – Preflight Collisions:** detect path/slug collisions and let users skip or overwrite.
+- [ ] **T7 – Sync Executor:** apply create/update operations with progress and retry logic.
+- [ ] **T8 – Report & Rescan:** final summary and option to rescan or quit.
+- [ ] **T9 – Keybind Help:** context-sensitive shortcut overlay.
+- [ ] **T10 – Logging:** structured logging, no telemetry.
 
 ## Project Structure
+
 ```
 storyblok-sync/
 ├─ cmd/sbsync/            # entry point
@@ -43,7 +47,9 @@ storyblok-sync/
 │  └─ config/             # token/config loading and saving
 └─ testdata/              # JSON fixtures
 ```
+
 Future modules (`internal/core`, `infra`) will house the sync logic and infrastructure helpers described in the roadmap.
 
 ## Contributing
+
 See [AGENTS.md](AGENTS.md) for coding conventions and testing requirements. Submit pull requests with a short description of the change and note any deviations from the guidelines.


### PR DESCRIPTION
## Summary
- add repository-wide AGENTS.md with coding conventions and testing requirements
- document project roadmap and usage in README

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...` *(hangs, aborted after waiting)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3fa127d88329af6f2e2f7f61cfc9