### PR TITLE
test: add config and client tests

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg")
+	content := []byte("SB_TOKEN=abc\nSOURCE_SPACE_ID=1\nTARGET_SPACE_ID=2\n")
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Token != "abc" || cfg.SourceSpace != "1" || cfg.TargetSpace != "2" {
+		t.Fatalf("unexpected cfg: %+v", cfg)
+	}
+}
+
+func TestLoadFromEnv(t *testing.T) {
+	t.Setenv("SB_TOKEN", "envtoken")
+	cfg, err := Load(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatalf("Load returned error: %v", err)
+	}
+	if cfg.Token != "envtoken" {
+		t.Fatalf("expected token from env, got %q", cfg.Token)
+	}
+}
+
+func TestSaveWritesFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg")
+	cfg := Config{Token: "abc", SourceSpace: "1", TargetSpace: "2"}
+	if err := Save(path, cfg); err != nil {
+		t.Fatalf("Save returned error: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	expected := "SB_TOKEN=abc\nSOURCE_SPACE_ID=1\nTARGET_SPACE_ID=2\n"
+	if string(data) != expected {
+		t.Fatalf("file content = %q, want %q", string(data), expected)
+	}
+}
+
+func TestSaveRequiresToken(t *testing.T) {
+	if err := Save("ignored", Config{}); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}

--- a/internal/sb/client_test.go
+++ b/internal/sb/client_test.go
@@ -1,0 +1,80 @@
+package sb
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestListSpaces(t *testing.T) {
+	c := New("token")
+	c.http = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("Authorization") != "token" {
+			t.Fatalf("unexpected token header: %s", req.Header.Get("Authorization"))
+		}
+		body := `{"spaces":[{"id":1,"name":"one"}]}`
+		res := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}
+		return res, nil
+	})}
+	spaces, err := c.ListSpaces(context.Background())
+	if err != nil {
+		t.Fatalf("ListSpaces returned error: %v", err)
+	}
+	if len(spaces) != 1 || spaces[0].ID != 1 || spaces[0].Name != "one" {
+		t.Fatalf("unexpected spaces: %+v", spaces)
+	}
+}
+
+func TestListSpacesNoToken(t *testing.T) {
+	c := New("")
+	if _, err := c.ListSpaces(context.Background()); err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestListStoriesPagination(t *testing.T) {
+	c := New("token")
+	calls := 0
+	c.http = &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+		q := req.URL.Query()
+		page := q.Get("page")
+		var body string
+		switch page {
+		case "1":
+			body = `{"stories":[{"id":1,"name":"a"},{"id":2,"name":"b"}]}`
+		case "2":
+			body = `{"stories":[{"id":3,"name":"c"}]}`
+		default:
+			t.Fatalf("unexpected page %s", page)
+		}
+		res := &http.Response{
+			StatusCode: 200,
+			Body:       io.NopCloser(strings.NewReader(body)),
+			Header:     make(http.Header),
+		}
+		return res, nil
+	})}
+	stories, err := c.ListStories(context.Background(), ListStoriesOpts{SpaceID: 1, PerPage: 2})
+	if err != nil {
+		t.Fatalf("ListStories returned error: %v", err)
+	}
+	if len(stories) != 3 {
+		t.Fatalf("expected 3 stories, got %d", len(stories))
+	}
+	if calls != 2 {
+		t.Fatalf("expected 2 calls, got %d", calls)
+	}
+}


### PR DESCRIPTION
## Summary
- add configuration load/save tests
- cover Storyblok client auth and pagination

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa44da79408329b4b9a13a5d79d854