### PR TITLE
feat: add foldable story tree

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -99,6 +99,11 @@ type Model struct {
 	storiesSource []sb.Story
 	storiesTarget []sb.Story
 
+	// tree state
+	storyIdx        map[int]int  // Story ID -> index in storiesSource
+	folderCollapsed map[int]bool // Folder ID -> collapsed?
+	visibleIdx      []int        // indices of visible storiesSource entries
+
 	selection SelectionState
 	filter    FilterState
 	search    SearchState
@@ -132,6 +137,8 @@ func InitialModel() Model {
 	ti.CharLimit = 200
 	m.ti = ti
 	m.selection.selected = make(map[string]bool)
+	m.folderCollapsed = make(map[int]bool)
+	m.storyIdx = make(map[int]int)
 
 	// search
 	si := textinput.New()

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"storyblok-sync/internal/sb"
 )
 
 // TestHandleWelcomeKey verifies state transitions from the welcome screen.
@@ -44,5 +46,67 @@ func TestUpdateGlobalQuit(t *testing.T) {
 		t.Fatalf("expected quit msg")
 	} else if _, ok := msg.(tea.QuitMsg); !ok {
 		t.Fatalf("expected tea.QuitMsg, got %T", msg)
+	}
+}
+
+func TestFolderFoldingNavigation(t *testing.T) {
+	folderID := 1
+	childID := 2
+	folder := sb.Story{ID: folderID, Name: "folder", Slug: "folder", FullSlug: "folder", IsFolder: true}
+	folderIDPtr := folderID
+	child := sb.Story{ID: childID, Name: "child", Slug: "child", FullSlug: "folder/child", FolderID: &folderIDPtr}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{folder, child}
+	m.rebuildStoryIndex()
+	m.applyFilter()
+
+	if got := m.itemsLen(); got != 1 {
+		t.Fatalf("expected 1 item, got %d", got)
+	}
+
+	m, _ = m.handleBrowseListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if got := m.itemsLen(); got != 2 {
+		t.Fatalf("expected 2 items after expand, got %d", got)
+	}
+
+	m.selection.listIndex = 1
+	m, _ = m.handleBrowseListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'h'}})
+	if got := m.itemsLen(); got != 1 {
+		t.Fatalf("expected 1 item after collapse, got %d", got)
+	}
+	if m.selection.listIndex != 0 {
+		t.Fatalf("expected cursor on parent, got %d", m.selection.listIndex)
+	}
+}
+
+func TestSearchExpandsAndCollapses(t *testing.T) {
+	folderID := 1
+	childID := 2
+	folder := sb.Story{ID: folderID, Name: "folder", Slug: "folder", FullSlug: "folder", IsFolder: true}
+	folderIDPtr := folderID
+	child := sb.Story{ID: childID, Name: "child", Slug: "child", FullSlug: "folder/child", FolderID: &folderIDPtr}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{folder, child}
+	m.rebuildStoryIndex()
+	m.applyFilter()
+
+	if !m.folderCollapsed[folderID] {
+		t.Fatalf("expected folder collapsed initially")
+	}
+
+	m.search.searching = true
+	m.search.searchInput.Focus()
+	m, _ = m.handleBrowseListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if m.folderCollapsed[folderID] {
+		t.Fatalf("expected folder expanded after typing")
+	}
+
+	m.search.searching = false
+	m.search.query = "a"
+	m, _ = m.handleBrowseListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'F'}})
+	if !m.folderCollapsed[folderID] {
+		t.Fatalf("expected folder collapsed after clearing search")
 	}
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -244,7 +244,7 @@ func (m Model) viewBrowseList() string {
 	}
 	b.WriteString("\n")
 	b.WriteString(subtleStyle.Render(fmt.Sprintf("Markiert: %d", checked)) + "\n")
-	b.WriteString(helpStyle.Render("j/k bewegen  |  space Story markieren  |  r rescan  |  s preflight  |  q beenden") + "\n")
+	b.WriteString(helpStyle.Render("j/k bewegen  |  h/l falten  |  H alles zu  |  L alles auf  |  space Story markieren  |  r rescan  |  s preflight  |  q beenden") + "\n")
 	b.WriteString(helpStyle.Render("p Prefix  |  P Prefix löschen  |  f suchen |  F Suche löschen  |  c Filter löschen  |  Enter schließen  |  Esc löschen/zurück"))
 	return b.String()
 }


### PR DESCRIPTION
## Summary
- make story list tree collapsible with `h`/`l` and global `H`/`L`
- auto expand all folders while searching and collapse when cleared
- cover folding logic with tests

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa582f5a30832990b5ce1232cb1d3f