### PR TITLE
feat: differentiate folder markers for nested selections

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -631,3 +631,16 @@ func (m Model) hasSelectedDescendant(slug string) bool {
 	}
 	return false
 }
+
+func (m Model) hasSelectedDirectChild(slug string) bool {
+	prefix := slug + "/"
+	for s, v := range m.selection.selected {
+		if v && strings.HasPrefix(s, prefix) {
+			rest := strings.TrimPrefix(s, prefix)
+			if !strings.Contains(rest, "/") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -184,7 +184,7 @@ func TestNestedFolderMarkingIndicator(t *testing.T) {
 	m.selection.listViewport = 10
 
 	out := m.viewBrowseList()
-	if !strings.Contains(out, markNestedStyle.Render("•")) {
-		t.Fatalf("expected '•' marker for folder with selected descendant")
+	if !strings.Contains(out, markNestedStyle.Render("·")) {
+		t.Fatalf("expected '·' marker for folder with selected descendant")
 	}
 }

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -161,3 +161,30 @@ func TestPartialFolderMarkingIndicator(t *testing.T) {
 		t.Fatalf("expected ':' marker for folder with selected child")
 	}
 }
+
+func TestNestedFolderMarkingIndicator(t *testing.T) {
+	rootID := 1
+	subID := 2
+	childID := 3
+	root := sb.Story{ID: rootID, Name: "root", Slug: "root", FullSlug: "root", IsFolder: true}
+	rootPtr := rootID
+	sub := sb.Story{ID: subID, Name: "sub", Slug: "sub", FullSlug: "root/sub", IsFolder: true, FolderID: &rootPtr}
+	subPtr := subID
+	child := sb.Story{ID: childID, Name: "child", Slug: "child", FullSlug: "root/sub/child", FolderID: &subPtr}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{root, sub, child}
+	m.rebuildStoryIndex()
+	m.applyFilter()
+	if m.selection.selected == nil {
+		m.selection.selected = make(map[string]bool)
+	}
+	m.selection.selected[child.FullSlug] = true
+	m.refreshVisible()
+	m.selection.listViewport = 10
+
+	out := m.viewBrowseList()
+	if !strings.Contains(out, markNestedStyle.Render("•")) {
+		t.Fatalf("expected '•' marker for folder with selected descendant")
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -203,8 +203,12 @@ func (m Model) viewBrowseList() string {
 				markCell := " "
 				if m.selection.selected[st.FullSlug] {
 					markCell = markBarStyle.Render(" ")
-				} else if st.IsFolder && m.hasSelectedDescendant(st.FullSlug) {
-					markCell = markNestedStyle.Render(":")
+				} else if st.IsFolder {
+					if m.hasSelectedDirectChild(st.FullSlug) {
+						markCell = markNestedStyle.Render(":")
+					} else if m.hasSelectedDescendant(st.FullSlug) {
+						markCell = markNestedStyle.Render("•")
+					}
 				}
 
 				lines[i] = cursorCell + markCell + content

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -207,7 +207,7 @@ func (m Model) viewBrowseList() string {
 					if m.hasSelectedDirectChild(st.FullSlug) {
 						markCell = markNestedStyle.Render(":")
 					} else if m.hasSelectedDescendant(st.FullSlug) {
-						markCell = markNestedStyle.Render("•")
+						markCell = markNestedStyle.Render("·")
 					}
 				}
 


### PR DESCRIPTION
## Summary
- show ':' on folders with directly selected children
- show '•' when only deeper descendants are selected
- test folder markers for direct and nested selections

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa624aa7d08329b009b1d15d263a80