### PR TITLE
feat: advance cursor after marking

### DIFF
--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -375,6 +375,10 @@ func (m Model) handleBrowseListKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		} else {
 			m.selection.selected[st.FullSlug] = !m.selection.selected[st.FullSlug]
 		}
+		if m.selection.listIndex < m.itemsLen()-1 {
+			m.selection.listIndex++
+			m.ensureCursorVisible()
+		}
 
 	case "r":
 		m.state = stateScanning

--- a/internal/ui/update_test.go
+++ b/internal/ui/update_test.go
@@ -188,3 +188,26 @@ func TestNestedFolderMarkingIndicator(t *testing.T) {
 		t.Fatalf("expected '·' marker for folder with selected descendant")
 	}
 }
+
+func TestMarkMovesCursorDown(t *testing.T) {
+	st1 := sb.Story{ID: 1, Name: "one", Slug: "one", FullSlug: "one"}
+	st2 := sb.Story{ID: 2, Name: "two", Slug: "two", FullSlug: "two"}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{st1, st2}
+	m.rebuildStoryIndex()
+	m.applyFilter()
+
+	if m.selection.listIndex != 0 {
+		t.Fatalf("expected cursor at 0, got %d", m.selection.listIndex)
+	}
+
+	m, _ = m.handleBrowseListKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	if !m.selection.selected[st1.FullSlug] {
+		t.Fatalf("expected first story selected")
+	}
+	if m.selection.listIndex != 1 {
+		t.Fatalf("expected cursor moved to 1, got %d", m.selection.listIndex)
+	}
+}


### PR DESCRIPTION
## Summary
- move cursor to next item after marking to ease mass marking
- test cursor advancement on mark

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aa66c530ac83298a25554ed1c0bb37