### PR TITLE
feat: sort stories by type and name

### DIFF
--- a/internal/ui/sort.go
+++ b/internal/ui/sort.go
@@ -1,0 +1,42 @@
+package ui
+
+import (
+	"sort"
+	"strings"
+
+	"storyblok-sync/internal/sb"
+)
+
+// sortStories orders the slice so that folders come first, followed by root stories
+// (startpages) and finally regular stories. Items of the same type are sorted by
+// their display name in a case-insensitive manner.
+func sortStories(stories []sb.Story) {
+	sort.SliceStable(stories, func(i, j int) bool {
+		a, b := stories[i], stories[j]
+		pa, pb := sortPriority(a), sortPriority(b)
+		if pa != pb {
+			return pa < pb
+		}
+		na := strings.ToLower(displayName(a))
+		nb := strings.ToLower(displayName(b))
+		return na < nb
+	})
+}
+
+func sortPriority(st sb.Story) int {
+	switch {
+	case st.IsFolder:
+		return 0
+	case st.IsStartpage:
+		return 1
+	default:
+		return 2
+	}
+}
+
+func displayName(st sb.Story) string {
+	if st.Name != "" {
+		return st.Name
+	}
+	return st.Slug
+}

--- a/internal/ui/sort_test.go
+++ b/internal/ui/sort_test.go
@@ -1,0 +1,27 @@
+package ui
+
+import (
+	"testing"
+
+	"storyblok-sync/internal/sb"
+)
+
+func TestSortStoriesByTypeAndName(t *testing.T) {
+	stories := []sb.Story{
+		{ID: 1, Name: "storyB"},
+		{ID: 2, Name: "folderB", IsFolder: true},
+		{ID: 3, Name: "rootA", IsStartpage: true},
+		{ID: 4, Name: "storyA"},
+		{ID: 5, Name: "folderA", IsFolder: true},
+		{ID: 6, Name: "rootB", IsStartpage: true},
+	}
+
+	sortStories(stories)
+
+	want := []int{5, 2, 3, 6, 4, 1}
+	for i, st := range stories {
+		if st.ID != want[i] {
+			t.Fatalf("at %d want %d got %d", i, want[i], st.ID)
+		}
+	}
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -436,10 +436,12 @@ func (m Model) scanStoriesCmd() tea.Cmd {
 		if err != nil {
 			return scanMsg{err: fmt.Errorf("source scan: %w", err)}
 		}
+		sortStories(src)
 		tgt, err := c.ListStories(ctx, sb.ListStoriesOpts{SpaceID: tgtID, PerPage: 50})
 		if err != nil {
 			return scanMsg{err: fmt.Errorf("target scan: %w", err)}
 		}
+		sortStories(tgt)
 		return scanMsg{src: src, tgt: tgt, err: nil}
 	}
 }


### PR DESCRIPTION
## Summary
- sort stories by folder, startpage, and regular type
- list items of the same type alphabetically by name
- test sorting order

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aab0b01d148329bec671d57c15e886