### PR TITLE
feat: add preflight collision check

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -24,7 +24,7 @@ var (
 	cursorBarStyle  = lipgloss.NewStyle().Background(lipgloss.Color("#FFAB78"))
 	markBarStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#3AC4BA"))
 	markNestedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#3AC4BA"))
-	collisionSign   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("⚠")
+	collisionSign   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("!")
 
 	// markers for different story types (colored squares)
 	symbolStory  = fgSymbol("#8942E1", "S")

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -24,6 +24,7 @@ var (
 	cursorBarStyle  = lipgloss.NewStyle().Background(lipgloss.Color("#FFAB78"))
 	markBarStyle    = lipgloss.NewStyle().Background(lipgloss.Color("#3AC4BA"))
 	markNestedStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#3AC4BA"))
+	collisionSign   = lipgloss.NewStyle().Foreground(lipgloss.Color("11")).Render("⚠")
 
 	// markers for different story types (colored squares)
 	symbolStory  = fgSymbol("#8942E1", "S")
@@ -47,6 +48,7 @@ const (
 	stateSpaceSelect
 	stateScanning
 	stateBrowseList
+	statePreflight
 	stateQuit
 )
 
@@ -71,6 +73,24 @@ type SearchState struct {
 	searchInput textinput.Model
 	query       string // aktueller Suchstring
 	filteredIdx []int  // Mapping: sichtbarer Index -> original Index
+}
+
+type PreflightItem struct {
+	Story     sb.Story
+	Collision bool
+	Skip      bool
+	Selected  bool
+}
+
+type PreflightState struct {
+	items        []PreflightItem
+	listIndex    int
+	listOffset   int
+	listViewport int
+}
+
+type SyncPlan struct {
+	Items []PreflightItem
 }
 
 type Model struct {
@@ -108,6 +128,9 @@ type Model struct {
 	filter    FilterState
 	search    SearchState
 	filterCfg FilterConfig // Konfiguration für Such- und Filterparameter
+
+	preflight PreflightState
+	plan      SyncPlan
 }
 
 func InitialModel() Model {

--- a/internal/ui/preflight_test.go
+++ b/internal/ui/preflight_test.go
@@ -1,0 +1,63 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"storyblok-sync/internal/sb"
+)
+
+func TestStartPreflightDetectsCollisions(t *testing.T) {
+	st1 := sb.Story{ID: 1, Name: "one", Slug: "one", FullSlug: "one"}
+	st2 := sb.Story{ID: 2, Name: "two", Slug: "two", FullSlug: "two"}
+	tgt := sb.Story{ID: 3, Name: "one", Slug: "one", FullSlug: "one"}
+	m := InitialModel()
+	m.storiesSource = []sb.Story{st1, st2}
+	m.storiesTarget = []sb.Story{tgt}
+	m.rebuildStoryIndex()
+	m.applyFilter()
+	if m.selection.selected == nil {
+		m.selection.selected = make(map[string]bool)
+	}
+	m.selection.selected[st1.FullSlug] = true
+
+	m.startPreflight()
+	if m.state != statePreflight {
+		t.Fatalf("expected statePreflight, got %v", m.state)
+	}
+	if len(m.preflight.items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(m.preflight.items))
+	}
+	if !m.preflight.items[0].Collision {
+		t.Fatalf("expected collision for first item")
+	}
+}
+
+func TestPreflightSkipToggleAndGlobal(t *testing.T) {
+	st := sb.Story{ID: 1, Name: "one", Slug: "one", FullSlug: "one"}
+	tgt := sb.Story{ID: 2, Name: "one", Slug: "one", FullSlug: "one"}
+	m := InitialModel()
+	m.storiesSource = []sb.Story{st}
+	m.storiesTarget = []sb.Story{tgt}
+	m.rebuildStoryIndex()
+	m.applyFilter()
+	if m.selection.selected == nil {
+		m.selection.selected = make(map[string]bool)
+	}
+	m.selection.selected[st.FullSlug] = true
+	m.startPreflight()
+
+	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if !m.preflight.items[0].Skip {
+		t.Fatalf("expected item skipped after x")
+	}
+	m.preflight.items[0].Skip = false
+	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
+	if !m.preflight.items[0].Skip {
+		t.Fatalf("expected item skipped after X")
+	}
+	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if m.state != stateBrowseList {
+		t.Fatalf("expected return to browse list on q")
+	}
+}

--- a/internal/ui/preflight_test.go
+++ b/internal/ui/preflight_test.go
@@ -91,8 +91,11 @@ func TestPreflightSkipToggleAndGlobal(t *testing.T) {
 		t.Fatalf("expected item skipped after X")
 	}
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
-	if m.preflight.items[0].Skip {
-		t.Fatalf("expected item unskipped after c")
+	if m.selection.selected[st.FullSlug] {
+		t.Fatalf("expected selection removed after c")
+	}
+	if len(m.preflight.items) != 0 {
+		t.Fatalf("expected preflight list cleared after c, got %d", len(m.preflight.items))
 	}
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if m.state != stateBrowseList {

--- a/internal/ui/preflight_test.go
+++ b/internal/ui/preflight_test.go
@@ -90,6 +90,10 @@ func TestPreflightSkipToggleAndGlobal(t *testing.T) {
 	if !m.preflight.items[0].Skip {
 		t.Fatalf("expected item skipped after X")
 	}
+	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	if m.preflight.items[0].Skip {
+		t.Fatalf("expected item unskipped after c")
+	}
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if m.state != stateBrowseList {
 		t.Fatalf("expected return to browse list on q")

--- a/internal/ui/preflight_test.go
+++ b/internal/ui/preflight_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -92,5 +93,26 @@ func TestPreflightSkipToggleAndGlobal(t *testing.T) {
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if m.state != stateBrowseList {
 		t.Fatalf("expected return to browse list on q")
+	}
+}
+
+func TestDisplayPreflightItemDimsSlug(t *testing.T) {
+	it := PreflightItem{Story: sb.Story{ID: 1, Name: "one", Slug: "one", FullSlug: "one"}}
+	s := displayPreflightItem(it)
+	expected := fmt.Sprintf("%s one  (one)", symbolStory)
+	if s != expected {
+		t.Fatalf("unexpected render for selected item: %q", s)
+	}
+	it.Selected = false
+	s = displayPreflightItem(it)
+	expected = fmt.Sprintf("%s %s  %s", symbolStory, subtleStyle.Render("one"), subtleStyle.Render("(one)"))
+	if s != expected {
+		t.Fatalf("expected dimmed slug and name when unselected: %q", s)
+	}
+	it.Selected = true
+	it.Skip = true
+	s = displayPreflightItem(it)
+	if s != expected {
+		t.Fatalf("expected dimmed slug and name when skipped: %q", s)
 	}
 }

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -422,8 +422,15 @@ func (m Model) handlePreflightKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 			}
 		}
 	case "c":
-		for i := range m.preflight.items {
-			m.preflight.items[i].Skip = false
+		removed := false
+		for _, it := range m.preflight.items {
+			if it.Skip {
+				delete(m.selection.selected, it.Story.FullSlug)
+				removed = true
+			}
+		}
+		if removed {
+			m.startPreflight()
 		}
 	case "esc", "q":
 		m.state = stateBrowseList
@@ -458,6 +465,7 @@ func (m *Model) startPreflight() {
 		}
 	}
 	if len(included) == 0 {
+		m.preflight = PreflightState{listViewport: m.selection.listViewport}
 		m.statusMsg = "Keine Stories markiert."
 		return
 	}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -475,7 +475,8 @@ func (m *Model) startPreflight() {
 	var walk func(int)
 	walk = func(idx int) {
 		st := m.storiesSource[idx]
-		it := PreflightItem{Story: st, Collision: target[st.FullSlug], Selected: m.selection.selected[st.FullSlug]}
+		sel := m.selection.selected[st.FullSlug]
+		it := PreflightItem{Story: st, Collision: sel && target[st.FullSlug], Selected: sel}
 		items = append(items, it)
 		for _, ch := range children[idx] {
 			walk(ch)

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -18,6 +18,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		key := msg.String()
+		if m.state == statePreflight {
+			return m.handlePreflightKey(msg)
+		}
 
 		// global shortcuts
 		if key == "ctrl+c" || key == "q" {
@@ -48,6 +51,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			vp = 3
 		}
 		m.selection.listViewport = vp
+		m.preflight.listViewport = vp
 
 	case validateMsg:
 		if msg.err != nil {
@@ -385,10 +389,172 @@ func (m Model) handleBrowseListKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		m.statusMsg = "Rescan…"
 		return m, m.scanStoriesCmd()
 	case "s":
-		// Weiter zu Preflight in T6 – hier nur Platzhalter
-		m.statusMsg = "Preflight (T6) folgt …"
+		m.startPreflight()
+		return m, nil
 	}
 	return m, nil
+}
+
+func (m Model) handlePreflightKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "j", "down":
+		if m.preflight.listIndex < len(m.preflight.items)-1 {
+			m.preflight.listIndex++
+			m.ensurePreflightCursorVisible()
+		}
+	case "k", "up":
+		if m.preflight.listIndex > 0 {
+			m.preflight.listIndex--
+			m.ensurePreflightCursorVisible()
+		}
+	case "x":
+		if len(m.preflight.items) > 0 {
+			it := &m.preflight.items[m.preflight.listIndex]
+			if it.Collision {
+				it.Skip = !it.Skip
+			}
+		}
+	case "X":
+		for i := range m.preflight.items {
+			if m.preflight.items[i].Collision {
+				m.preflight.items[i].Skip = true
+			}
+		}
+	case "esc", "q":
+		m.state = stateBrowseList
+		return m, nil
+	case "enter":
+		m.plan = SyncPlan{Items: append([]PreflightItem(nil), m.preflight.items...)}
+		skipped := 0
+		for _, it := range m.preflight.items {
+			if it.Skip {
+				skipped++
+			}
+		}
+		m.statusMsg = fmt.Sprintf("SyncPlan erstellt: %d Items, %d skipped", len(m.preflight.items), skipped)
+		m.state = stateBrowseList
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m *Model) startPreflight() {
+	target := make(map[string]bool, len(m.storiesTarget))
+	for _, st := range m.storiesTarget {
+		target[st.FullSlug] = true
+	}
+	included := make(map[int]bool)
+	for slug, v := range m.selection.selected {
+		if !v {
+			continue
+		}
+		if idx := m.indexBySlug(slug); idx >= 0 {
+			m.includeAncestors(idx, included)
+		}
+	}
+	if len(included) == 0 {
+		m.statusMsg = "Keine Stories markiert."
+		return
+	}
+	children := make(map[int][]int)
+	roots := make([]int, 0)
+	for i, st := range m.storiesSource {
+		if !included[i] {
+			continue
+		}
+		if st.FolderID != nil {
+			if pIdx, ok := m.storyIdx[*st.FolderID]; ok && included[pIdx] {
+				children[pIdx] = append(children[pIdx], i)
+				continue
+			}
+		}
+		roots = append(roots, i)
+	}
+	items := make([]PreflightItem, 0, len(included))
+	var walk func(int)
+	walk = func(idx int) {
+		st := m.storiesSource[idx]
+		it := PreflightItem{Story: st, Collision: target[st.FullSlug], Selected: m.selection.selected[st.FullSlug]}
+		items = append(items, it)
+		for _, ch := range children[idx] {
+			walk(ch)
+		}
+	}
+	for _, r := range roots {
+		walk(r)
+	}
+	m.preflight = PreflightState{items: items, listIndex: 0, listOffset: 0, listViewport: m.selection.listViewport}
+	m.state = statePreflight
+	collisions := 0
+	for _, it := range items {
+		if it.Collision {
+			collisions++
+		}
+	}
+	m.statusMsg = fmt.Sprintf("Preflight: %d Items, %d Kollisionen", len(items), collisions)
+}
+
+func (m *Model) indexBySlug(slug string) int {
+	for i, st := range m.storiesSource {
+		if st.FullSlug == slug {
+			return i
+		}
+	}
+	return -1
+}
+
+func (m *Model) includeAncestors(idx int, inc map[int]bool) {
+	for {
+		if inc[idx] {
+			return
+		}
+		inc[idx] = true
+		st := m.storiesSource[idx]
+		if st.FolderID == nil {
+			return
+		}
+		pIdx, ok := m.storyIdx[*st.FolderID]
+		if !ok {
+			return
+		}
+		idx = pIdx
+	}
+}
+
+func (m *Model) ensurePreflightCursorVisible() {
+	vp := m.preflight.listViewport
+	if vp <= 0 {
+		vp = 10
+	}
+	n := len(m.preflight.items)
+	if n == 0 {
+		m.preflight.listIndex = 0
+		m.preflight.listOffset = 0
+		return
+	}
+	if m.preflight.listIndex < 0 {
+		m.preflight.listIndex = 0
+	}
+	if m.preflight.listIndex > n-1 {
+		m.preflight.listIndex = n - 1
+	}
+	if m.preflight.listIndex < m.preflight.listOffset {
+		m.preflight.listOffset = m.preflight.listIndex
+	}
+	if m.preflight.listIndex >= m.preflight.listOffset+vp {
+		m.preflight.listOffset = m.preflight.listIndex - vp + 1
+	}
+	maxStart := n - vp
+	if maxStart < 0 {
+		maxStart = 0
+	}
+	if m.preflight.listOffset > maxStart {
+		m.preflight.listOffset = maxStart
+	}
+	if m.preflight.listOffset < 0 {
+		m.preflight.listOffset = 0
+	}
 }
 
 // ---------- Messages / Cmds ----------

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -421,6 +421,10 @@ func (m Model) handlePreflightKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 				m.preflight.items[i].Skip = true
 			}
 		}
+	case "c":
+		for i := range m.preflight.items {
+			m.preflight.items[i].Skip = false
+		}
 	case "esc", "q":
 		m.state = stateBrowseList
 		return m, nil

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -332,7 +332,7 @@ func (m Model) viewPreflight() string {
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("j/k bewegen  |  x skip  |  X alle skippen  |  Enter OK  |  esc/q zurück"))
+	b.WriteString(helpStyle.Render("j/k bewegen  |  x skip  |  X alle skippen  |  c skip zurücksetzen  |  Enter OK  |  esc/q zurück"))
 	return b.String()
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -272,7 +272,7 @@ func (m Model) viewPreflight() string {
 		tr := tree.New()
 		nodes := make(map[int]*tree.Tree, len(m.preflight.items))
 		for _, it := range m.preflight.items {
-			node := tree.Root(displayStory(it.Story))
+			node := tree.Root(displayPreflightItem(it))
 			nodes[it.Story.ID] = node
 		}
 		for _, it := range m.preflight.items {
@@ -301,8 +301,6 @@ func (m Model) viewPreflight() string {
 			}
 			if it.Skip {
 				content = subtleStyle.Render(content + " [skip]")
-			} else if !it.Selected {
-				content = subtleStyle.Render(content)
 			}
 			if i == m.preflight.listIndex {
 				content = cursorLineStyle.Width(m.width - 2).Render(content)
@@ -333,6 +331,20 @@ func (m Model) viewPreflight() string {
 	b.WriteString("\n")
 	b.WriteString(helpStyle.Render("j/k bewegen  |  x skip  |  X alle skippen  |  Enter OK  |  esc/q zurück"))
 	return b.String()
+}
+
+func displayPreflightItem(it PreflightItem) string {
+	name := it.Story.Name
+	if name == "" {
+		name = it.Story.Slug
+	}
+	slug := it.Story.FullSlug
+	if !it.Selected {
+		name = subtleStyle.Render(name)
+		slug = subtleStyle.Render(slug)
+	}
+	sym := storyTypeSymbol(it.Story)
+	return fmt.Sprintf("%s %s  (%s)", sym, name, slug)
 }
 
 func displayStory(st sb.Story) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -332,7 +332,7 @@ func (m Model) viewPreflight() string {
 		b.WriteString("\n")
 	}
 	b.WriteString("\n")
-	b.WriteString(helpStyle.Render("j/k bewegen  |  x skip  |  X alle skippen  |  c skip zurücksetzen  |  Enter OK  |  esc/q zurück"))
+	b.WriteString(helpStyle.Render("j/k bewegen  |  x skip  |  X alle skippen  |  c Skips entfernen  |  Enter OK  |  esc/q zurück"))
 	return b.String()
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -294,19 +294,22 @@ func (m Model) viewPreflight() string {
 				break
 			}
 			content := lines[i]
-			if it.Collision {
+			if it.Collision && it.Selected {
 				content = collisionSign + " " + content
 			} else {
 				content = "  " + content
 			}
 			if it.Skip {
-				content = subtleStyle.Render(content + " [skip]")
+				content += " [skip]"
 			}
+			lineStyle := lipgloss.NewStyle().Width(m.width - 2)
 			if i == m.preflight.listIndex {
-				content = cursorLineStyle.Width(m.width - 2).Render(content)
-			} else {
-				content = lipgloss.NewStyle().Width(m.width - 2).Render(content)
+				lineStyle = cursorLineStyle.Copy().Width(m.width - 2)
 			}
+			if it.Skip {
+				lineStyle = lineStyle.Faint(true)
+			}
+			content = lineStyle.Render(content)
 			cursorCell := " "
 			if i == m.preflight.listIndex {
 				cursorCell = cursorBarStyle.Render(" ")
@@ -338,13 +341,13 @@ func displayPreflightItem(it PreflightItem) string {
 	if name == "" {
 		name = it.Story.Slug
 	}
-	slug := it.Story.FullSlug
-	if !it.Selected {
+	slug := "(" + it.Story.FullSlug + ")"
+	if !it.Selected || it.Skip {
 		name = subtleStyle.Render(name)
 		slug = subtleStyle.Render(slug)
 	}
 	sym := storyTypeSymbol(it.Story)
-	return fmt.Sprintf("%s %s  (%s)", sym, name, slug)
+	return fmt.Sprintf("%s %s  %s", sym, name, slug)
 }
 
 func displayStory(st sb.Story) string {


### PR DESCRIPTION
## Summary
- detect slug collisions when entering preflight
- allow marking collisions for skip individually or en masse
- show expanded preflight tree with collision warnings

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aac8272e0883299c7a9323f06e4698