### PR TITLE
feat: display sync state in preflight

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -75,11 +75,32 @@ type SearchState struct {
 	filteredIdx []int  // Mapping: sichtbarer Index -> original Index
 }
 
+type syncState int
+
+const (
+	stateCreate syncState = iota
+	stateUpdate
+	stateSkip
+)
+
+func (s syncState) String() string {
+	switch s {
+	case stateCreate:
+		return "C"
+	case stateUpdate:
+		return "U"
+	case stateSkip:
+		return "S"
+	default:
+		return "?"
+	}
+}
+
 type PreflightItem struct {
 	Story     sb.Story
 	Collision bool
-	Skip      bool
 	Selected  bool
+	State     syncState
 }
 
 type PreflightState struct {

--- a/internal/ui/preflight_test.go
+++ b/internal/ui/preflight_test.go
@@ -82,12 +82,12 @@ func TestPreflightSkipToggleAndGlobal(t *testing.T) {
 	m.startPreflight()
 
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
-	if !m.preflight.items[0].Skip {
+	if m.preflight.items[0].State != stateSkip {
 		t.Fatalf("expected item skipped after x")
 	}
-	m.preflight.items[0].Skip = false
+	m.preflight.items[0].State = stateUpdate
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'X'}})
-	if !m.preflight.items[0].Skip {
+	if m.preflight.items[0].State != stateSkip {
 		t.Fatalf("expected item skipped after X")
 	}
 	m, _ = m.handlePreflightKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
@@ -117,7 +117,7 @@ func TestDisplayPreflightItemDimsSlug(t *testing.T) {
 		t.Fatalf("expected dimmed slug and name when unselected: %q", s)
 	}
 	it.Selected = true
-	it.Skip = true
+	it.State = stateSkip
 	s = displayPreflightItem(it)
 	if s != expected {
 		t.Fatalf("expected dimmed slug and name when skipped: %q", s)

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -299,14 +299,11 @@ func (m Model) viewPreflight() string {
 			} else {
 				content = "  " + content
 			}
-			if it.Skip {
-				content += " [skip]"
-			}
 			lineStyle := lipgloss.NewStyle().Width(m.width - 2)
 			if i == m.preflight.listIndex {
 				lineStyle = cursorLineStyle.Copy().Width(m.width - 2)
 			}
-			if it.Skip {
+			if it.State == stateSkip {
 				lineStyle = lineStyle.Faint(true)
 			}
 			content = lineStyle.Render(content)
@@ -314,11 +311,8 @@ func (m Model) viewPreflight() string {
 			if i == m.preflight.listIndex {
 				cursorCell = cursorBarStyle.Render(" ")
 			}
-			skipCell := " "
-			if it.Skip {
-				skipCell = markBarStyle.Render("x")
-			}
-			lines[i] = cursorCell + skipCell + content
+			stateCell := lipgloss.NewStyle().Width(1).Render(it.State.String())
+			lines[i] = cursorCell + stateCell + content
 		}
 		start := m.preflight.listOffset
 		if start > len(lines) {
@@ -342,7 +336,7 @@ func displayPreflightItem(it PreflightItem) string {
 		name = it.Story.Slug
 	}
 	slug := "(" + it.Story.FullSlug + ")"
-	if !it.Selected || it.Skip {
+	if !it.Selected || it.State == stateSkip {
 		name = subtleStyle.Render(name)
 		slug = subtleStyle.Render(slug)
 	}


### PR DESCRIPTION
## Summary
- add syncState enum and track state per preflight item
- show C/U/S state column on preflight screen
- update skip logic and tests for new state field

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68aaf73583248329b39bbeb7e0572555