### PR TITLE
feat: add story and folder sync

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -28,6 +28,7 @@ var (
 	stateCreateStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("10"))
 	stateUpdateStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("11"))
 	stateSkipStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	stateDoneStyle   = lipgloss.NewStyle().Background(lipgloss.Color("10")).Foreground(lipgloss.Color("0")).Bold(true)
 
 	// markers for different story types (colored squares)
 	symbolStory  = fgSymbol("#8942E1", "S")
@@ -94,12 +95,23 @@ var stateStyles = map[SyncState]lipgloss.Style{
 	StateSkip:   stateSkipStyle,
 }
 
+// RunState marks the execution state of a sync item.
+type RunState int
+
+const (
+	RunPending RunState = iota
+	RunRunning
+	RunDone
+)
+
 type PreflightItem struct {
-	Story     sb.Story
-	Collision bool
-	Skip      bool
-	Selected  bool
-	State     SyncState
+	Story      sb.Story
+	Collision  bool
+	Skip       bool
+	Selected   bool
+	State      SyncState
+	StartsWith bool
+	Run        RunState
 }
 
 func (it *PreflightItem) RecalcState() {
@@ -134,7 +146,9 @@ type Model struct {
 	width, height int
 
 	// spinner for loading states
-	spinner spinner.Model
+	spinner   spinner.Model
+	syncing   bool
+	syncIndex int
 
 	// token input
 	ti textinput.Model
@@ -162,6 +176,9 @@ type Model struct {
 
 	preflight PreflightState
 	plan      SyncPlan
+
+	client *sb.Client
+	report Report
 }
 
 func InitialModel() Model {
@@ -218,7 +235,7 @@ func InitialModel() Model {
 
 	// spinner
 	sp := spinner.New()
-	sp.Spinner = spinner.Line
+	sp.Spinner = spinner.Dot
 	sp.Style = subtleStyle
 	m.spinner = sp
 

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -1,0 +1,54 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+)
+
+type ReportStatus string
+
+const (
+	ReportSuccess ReportStatus = "success"
+	ReportFailure ReportStatus = "failure"
+	ReportWarning ReportStatus = "warning"
+)
+
+type ReportEntry struct {
+	Slug   string       `json:"slug"`
+	Status ReportStatus `json:"status"`
+	Error  string       `json:"error,omitempty"`
+}
+
+type Report struct {
+	Entries []ReportEntry `json:"entries"`
+}
+
+func (r *Report) AddSuccess(slug string) {
+	r.Entries = append(r.Entries, ReportEntry{Slug: slug, Status: ReportSuccess})
+}
+
+func (r *Report) AddFailure(slug string, err error) {
+	r.Entries = append(r.Entries, ReportEntry{Slug: slug, Status: ReportFailure, Error: err.Error()})
+}
+
+func (r *Report) Counts() (successes, warnings, failures int) {
+	for _, e := range r.Entries {
+		switch e.Status {
+		case ReportSuccess:
+			successes++
+		case ReportWarning:
+			warnings++
+		case ReportFailure:
+			failures++
+		}
+	}
+	return
+}
+
+func (r Report) Dump(path string) error {
+	data, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/ui/sync.go
+++ b/internal/ui/sync.go
@@ -1,0 +1,228 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"storyblok-sync/internal/sb"
+)
+
+type syncResultMsg struct {
+	index int
+	err   error
+}
+
+// optimizePreflight deduplicates entries and merges full folder selections into starts_with tasks.
+func (m *Model) optimizePreflight() {
+	selected := make(map[string]*PreflightItem)
+	for i := range m.preflight.items {
+		it := &m.preflight.items[i]
+		if it.Skip {
+			continue
+		}
+		if _, ok := selected[it.Story.FullSlug]; ok {
+			it.Skip = true
+			continue
+		}
+		selected[it.Story.FullSlug] = it
+	}
+	for _, it := range selected {
+		if !it.Story.IsFolder {
+			continue
+		}
+		prefix := it.Story.FullSlug + "/"
+		all := true
+		for _, st := range m.storiesSource {
+			if strings.HasPrefix(st.FullSlug, prefix) {
+				if _, ok := selected[st.FullSlug]; !ok {
+					all = false
+					break
+				}
+			}
+		}
+		if all {
+			it.StartsWith = true
+			for slug, ch := range selected {
+				if slug != it.Story.FullSlug && strings.HasPrefix(slug, prefix) {
+					ch.Skip = true
+				}
+			}
+		}
+	}
+	optimized := make([]PreflightItem, 0, len(m.preflight.items))
+	for _, it := range m.preflight.items {
+		if it.Skip {
+			continue
+		}
+		it.Run = RunPending
+		optimized = append(optimized, it)
+	}
+	m.preflight.items = optimized
+}
+
+func (m *Model) runNextItem() tea.Cmd {
+	if m.syncIndex >= len(m.preflight.items) {
+		return nil
+	}
+	idx := m.syncIndex
+	m.preflight.items[idx].Run = RunRunning
+	return func() tea.Msg {
+		it := m.preflight.items[idx]
+		// Step 1: ensure structure
+		err := m.syncStructure(it.Story)
+		if err == nil {
+			// Step 2: sync content
+			switch {
+			case it.StartsWith:
+				err = m.syncStartsWith(it.Story.FullSlug)
+			case it.Story.IsFolder:
+				// nothing more
+			default:
+				err = m.syncStory(it.Story)
+			}
+		}
+		if err == nil {
+			m.report.AddSuccess(it.Story.FullSlug)
+			time.Sleep(50 * time.Millisecond)
+		} else {
+			m.report.AddFailure(it.Story.FullSlug, err)
+		}
+		return syncResultMsg{index: idx, err: err}
+	}
+}
+
+func (m *Model) syncStructure(st sb.Story) error {
+	parts := strings.Split(st.FullSlug, "/")
+	if !st.IsFolder {
+		parts = parts[:len(parts)-1]
+	}
+	var parentID *int
+	var path []string
+	for _, p := range parts {
+		path = append(path, p)
+		full := strings.Join(path, "/")
+		if idx := m.findTarget(full); idx >= 0 {
+			id := m.storiesTarget[idx].ID
+			parentID = &id
+			continue
+		}
+		src, ok := m.findSource(full)
+		if !ok {
+			src = sb.Story{Name: p, Slug: p, FullSlug: full, IsFolder: true}
+		}
+		if parentID != nil {
+			id := *parentID
+			src.FolderID = &id
+		} else {
+			src.FolderID = nil
+		}
+		src.IsFolder = true
+		if m.client != nil && m.targetSpace != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			created, err := m.client.CreateStory(ctx, m.targetSpace.ID, src)
+			cancel()
+			if err != nil {
+				return fmt.Errorf("create folder %s: %w", full, err)
+			}
+			src = created
+		} else {
+			src.ID = m.nextTargetID()
+		}
+		m.storiesTarget = append(m.storiesTarget, src)
+		id := src.ID
+		parentID = &id
+	}
+	return nil
+}
+
+func (m *Model) syncStory(st sb.Story) error {
+	if idx := m.findTarget(st.FullSlug); idx >= 0 {
+		existing := m.storiesTarget[idx]
+		st.ID = existing.ID
+		st.FolderID = existing.FolderID
+		if m.client != nil && m.targetSpace != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			_, err := m.client.UpdateStory(ctx, m.targetSpace.ID, st)
+			cancel()
+			if err != nil {
+				return fmt.Errorf("update story %s: %w", st.FullSlug, err)
+			}
+		}
+		m.storiesTarget[idx] = st
+		return nil
+	}
+	if parent := parentSlug(st.FullSlug); parent != "" {
+		if idx := m.findTarget(parent); idx >= 0 {
+			id := m.storiesTarget[idx].ID
+			st.FolderID = &id
+		}
+	}
+	if m.client != nil && m.targetSpace != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		created, err := m.client.CreateStory(ctx, m.targetSpace.ID, st)
+		cancel()
+		if err != nil {
+			return fmt.Errorf("create story %s: %w", st.FullSlug, err)
+		}
+		st = created
+	} else {
+		st.ID = m.nextTargetID()
+	}
+	m.storiesTarget = append(m.storiesTarget, st)
+	return nil
+}
+
+func (m *Model) syncStartsWith(slug string) error {
+	for _, st := range m.storiesSource {
+		if st.FullSlug == slug || strings.HasPrefix(st.FullSlug, slug+"/") {
+			if err := m.syncStructure(st); err != nil {
+				return err
+			}
+			if !st.IsFolder {
+				if err := m.syncStory(st); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Model) findTarget(fullSlug string) int {
+	for i, st := range m.storiesTarget {
+		if st.FullSlug == fullSlug {
+			return i
+		}
+	}
+	return -1
+}
+
+func (m *Model) findSource(fullSlug string) (sb.Story, bool) {
+	for _, st := range m.storiesSource {
+		if st.FullSlug == fullSlug {
+			return st, true
+		}
+	}
+	return sb.Story{}, false
+}
+
+func (m *Model) nextTargetID() int {
+	max := 0
+	for _, st := range m.storiesTarget {
+		if st.ID > max {
+			max = st.ID
+		}
+	}
+	return max + 1
+}
+
+func parentSlug(full string) string {
+	if i := strings.LastIndex(full, "/"); i >= 0 {
+		return full[:i]
+	}
+	return ""
+}

--- a/internal/ui/sync_test.go
+++ b/internal/ui/sync_test.go
@@ -1,0 +1,92 @@
+package ui
+
+import (
+	"testing"
+
+	"storyblok-sync/internal/sb"
+)
+
+func TestSyncStructureCreatesFolders(t *testing.T) {
+	root := sb.Story{ID: 1, Name: "a__portal", Slug: "a__portal", FullSlug: "a__portal", IsFolder: true}
+	de := sb.Story{ID: 2, Name: "de", Slug: "de", FullSlug: "a__portal/de", FolderID: &root.ID, IsFolder: true}
+	shop := sb.Story{ID: 3, Name: "shop", Slug: "shop", FullSlug: "a__portal/de/shop", FolderID: &de.ID, IsFolder: true}
+	detail := sb.Story{ID: 4, Name: "detail", Slug: "detail", FullSlug: "a__portal/de/shop/detail", FolderID: &shop.ID, IsFolder: true}
+	item := sb.Story{ID: 5, Name: "item1", Slug: "item1", FullSlug: "a__portal/de/shop/detail/item1", FolderID: &detail.ID}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{root, de, shop, detail, item}
+
+	if err := m.syncStructure(item); err != nil {
+		t.Fatalf("syncStructure returned error: %v", err)
+	}
+
+	expected := []string{root.FullSlug, de.FullSlug, shop.FullSlug, detail.FullSlug}
+	if len(m.storiesTarget) != len(expected) {
+		t.Fatalf("expected %d folders, got %d", len(expected), len(m.storiesTarget))
+	}
+	for _, slug := range expected {
+		if idx := m.findTarget(slug); idx < 0 {
+			t.Fatalf("folder %s not created", slug)
+		}
+	}
+}
+
+func TestSyncStoryCreatesAndUpdates(t *testing.T) {
+	folder := sb.Story{ID: 1, Name: "app", Slug: "app", FullSlug: "app", IsFolder: true}
+	story := sb.Story{ID: 2, Name: "one", Slug: "one", FullSlug: "app/one", FolderID: &folder.ID}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{folder, story}
+
+	if err := m.syncStructure(story); err != nil {
+		t.Fatalf("syncStructure: %v", err)
+	}
+	if err := m.syncStory(story); err != nil {
+		t.Fatalf("syncStory create: %v", err)
+	}
+	if idx := m.findTarget(story.FullSlug); idx < 0 {
+		t.Fatalf("story not created")
+	}
+
+	updated := story
+	updated.Name = "eins"
+	if err := m.syncStory(updated); err != nil {
+		t.Fatalf("syncStory update: %v", err)
+	}
+	idx := m.findTarget(story.FullSlug)
+	if got := m.storiesTarget[idx].Name; got != "eins" {
+		t.Fatalf("expected updated name 'eins', got %q", got)
+	}
+	if len(m.storiesTarget) != 2 {
+		t.Fatalf("expected 2 items total, got %d", len(m.storiesTarget))
+	}
+}
+
+func TestSyncStartsWithCopiesSubtree(t *testing.T) {
+	parent := sb.Story{ID: 1, Name: "app", Slug: "app", FullSlug: "app", IsFolder: true}
+	child1 := sb.Story{ID: 2, Name: "one", Slug: "one", FullSlug: "app/one", FolderID: &parent.ID}
+	child2 := sb.Story{ID: 3, Name: "two", Slug: "two", FullSlug: "app/two", FolderID: &parent.ID}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{parent, child1, child2}
+
+	if err := m.syncStartsWith("app"); err != nil {
+		t.Fatalf("syncStartsWith: %v", err)
+	}
+	if len(m.storiesTarget) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(m.storiesTarget))
+	}
+	for _, slug := range []string{parent.FullSlug, child1.FullSlug, child2.FullSlug} {
+		if idx := m.findTarget(slug); idx < 0 {
+			t.Fatalf("missing %s", slug)
+		}
+	}
+	folderIdx := m.findTarget(parent.FullSlug)
+	folderID := m.storiesTarget[folderIdx].ID
+	for _, slug := range []string{child1.FullSlug, child2.FullSlug} {
+		idx := m.findTarget(slug)
+		if m.storiesTarget[idx].FolderID == nil || *m.storiesTarget[idx].FolderID != folderID {
+			t.Fatalf("child %s does not reference folder", slug)
+		}
+	}
+}

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -61,6 +61,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.spaces = msg.spaces
+		m.client = sb.New(m.cfg.Token)
 		m.statusMsg = fmt.Sprintf("Token ok. %d Spaces gefunden.", len(m.spaces))
 		// check if we have spaces configured and validate if their ids are in m.spaces
 		if m.cfg.SourceSpace != "" && m.cfg.TargetSpace != "" {
@@ -102,11 +103,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinner.TickMsg:
-		if m.state == stateValidating || m.state == stateScanning {
+		if m.state == stateValidating || m.state == stateScanning || (m.state == statePreflight && m.syncing) {
 			var cmd tea.Cmd
 			m.spinner, cmd = m.spinner.Update(msg)
 			return m, cmd
 		}
+		return m, nil
+
+	case syncResultMsg:
+		if msg.index < len(m.preflight.items) {
+			m.preflight.items[msg.index].Run = RunDone
+		}
+		done := 0
+		for _, it := range m.preflight.items {
+			if it.Run == RunDone {
+				done++
+			}
+		}
+		m.syncIndex = done
+		if done < len(m.preflight.items) {
+			return m, m.runNextItem()
+		}
+		m.syncing = false
+		succ, warn, fail := m.report.Counts()
+		m.statusMsg = fmt.Sprintf("Sync fertig: %d Erfolgreich, %d Warnungen, %d Fehler", succ, warn, fail)
+		_ = m.report.Dump("sync_report.json")
 		return m, nil
 	}
 
@@ -396,6 +417,9 @@ func (m Model) handleBrowseListKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 }
 
 func (m Model) handlePreflightKey(msg tea.KeyMsg) (Model, tea.Cmd) {
+	if m.syncing {
+		return m, nil
+	}
 	key := msg.String()
 	switch key {
 	case "j", "down":
@@ -438,16 +462,16 @@ func (m Model) handlePreflightKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 		m.state = stateBrowseList
 		return m, nil
 	case "enter":
-		m.plan = SyncPlan{Items: append([]PreflightItem(nil), m.preflight.items...)}
-		skipped := 0
-		for _, it := range m.preflight.items {
-			if it.Skip {
-				skipped++
-			}
+		m.optimizePreflight()
+		if len(m.preflight.items) == 0 {
+			m.statusMsg = "Keine Items zum Sync"
+			return m, nil
 		}
-		m.statusMsg = fmt.Sprintf("SyncPlan erstellt: %d Items, %d skipped", len(m.preflight.items), skipped)
-		m.state = stateBrowseList
-		return m, nil
+		m.plan = SyncPlan{Items: append([]PreflightItem(nil), m.preflight.items...)}
+		m.syncing = true
+		m.syncIndex = 0
+		m.statusMsg = fmt.Sprintf("Synchronisiere %d Items…", len(m.preflight.items))
+		return m, tea.Batch(m.spinner.Tick, m.runNextItem())
 	}
 	return m, nil
 }


### PR DESCRIPTION
## Summary
- extend Storyblok client with create/update helpers
- add sequential sync with reporting and progress tracking
- log results to JSON after run

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab0c263dec8329a443ece4cb5b3867