### PR TITLE
feat: remember created folder ids

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -166,6 +166,9 @@ type Model struct {
 	storiesSource []sb.Story
 	storiesTarget []sb.Story
 
+	// track created folders: source ID -> target ID
+	syncedFolders map[int]int
+
 	// tree state
 	storyIdx        map[int]int  // Story ID -> index in storiesSource
 	folderCollapsed map[int]bool // Folder ID -> collapsed?
@@ -209,6 +212,7 @@ func InitialModel() Model {
 	m.selection.selected = make(map[string]bool)
 	m.folderCollapsed = make(map[int]bool)
 	m.storyIdx = make(map[int]int)
+	m.syncedFolders = make(map[int]int)
 
 	// search
 	si := textinput.New()

--- a/internal/ui/sync.go
+++ b/internal/ui/sync.go
@@ -101,15 +101,25 @@ func (m *Model) syncStructure(st sb.Story) error {
 	for _, p := range parts {
 		path = append(path, p)
 		full := strings.Join(path, "/")
+		src, srcOK := m.findSource(full)
+		if srcOK {
+			if id, ok := m.syncedFolders[src.ID]; ok {
+				parentID = &id
+				continue
+			}
+		}
 		if idx := m.findTarget(full); idx >= 0 {
 			id := m.storiesTarget[idx].ID
 			parentID = &id
+			if srcOK {
+				m.syncedFolders[src.ID] = id
+			}
 			continue
 		}
-		src, ok := m.findSource(full)
-		if !ok {
+		if !srcOK {
 			src = sb.Story{Name: p, Slug: p, FullSlug: full, IsFolder: true}
 		}
+		srcID := src.ID
 		if m.api != nil && m.targetSpace != nil {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			payload := sb.Story{Name: src.Name, Slug: src.Slug, IsFolder: true}
@@ -123,6 +133,8 @@ func (m *Model) syncStructure(st sb.Story) error {
 				return err
 			}
 			src.ID = created.ID
+			src.Slug = created.Slug
+			src.FullSlug = created.FullSlug
 		} else {
 			src.ID = m.nextTargetID()
 			if parentID != nil {
@@ -136,6 +148,9 @@ func (m *Model) syncStructure(st sb.Story) error {
 			src.FolderID = &id
 		}
 		m.storiesTarget = append(m.storiesTarget, src)
+		if srcID != 0 {
+			m.syncedFolders[srcID] = src.ID
+		}
 		id := src.ID
 		parentID = &id
 	}

--- a/internal/ui/sync_test.go
+++ b/internal/ui/sync_test.go
@@ -90,3 +90,47 @@ func TestSyncStartsWithCopiesSubtree(t *testing.T) {
 		}
 	}
 }
+
+func TestSyncStructureTracksChangedSlugs(t *testing.T) {
+	root := sb.Story{ID: 1, Name: "root", Slug: "root", FullSlug: "root", IsFolder: true}
+	child := sb.Story{ID: 2, Name: "child", Slug: "child", FullSlug: "root/child", FolderID: &root.ID, IsFolder: true}
+	grand := sb.Story{ID: 3, Name: "grand", Slug: "grand", FullSlug: "root/child/grand", FolderID: &child.ID, IsFolder: true}
+
+	m := InitialModel()
+	m.storiesSource = []sb.Story{root, child, grand}
+
+	if err := m.syncStructure(child); err != nil {
+		t.Fatalf("syncStructure(child): %v", err)
+	}
+
+	rIdx := m.findTarget(root.FullSlug)
+	if rIdx < 0 {
+		t.Fatalf("root not created")
+	}
+	cIdx := m.findTarget(child.FullSlug)
+	if cIdx < 0 {
+		t.Fatalf("child not created")
+	}
+	childID := m.storiesTarget[cIdx].ID
+
+	// simulate API slug changes
+	m.storiesTarget[rIdx].Slug = "root-1"
+	m.storiesTarget[rIdx].FullSlug = "root-1"
+	m.storiesTarget[cIdx].Slug = "child-1"
+	m.storiesTarget[cIdx].FullSlug = "root-1/child-1"
+
+	if err := m.syncStructure(grand); err != nil {
+		t.Fatalf("syncStructure(grand): %v", err)
+	}
+
+	if len(m.storiesTarget) != 3 {
+		t.Fatalf("expected 3 folders, got %d", len(m.storiesTarget))
+	}
+	gIdx := m.findTarget(grand.FullSlug)
+	if gIdx < 0 {
+		t.Fatalf("grandchild not created")
+	}
+	if m.storiesTarget[gIdx].FolderID == nil || *m.storiesTarget[gIdx].FolderID != childID {
+		t.Fatalf("grandchild not linked to child")
+	}
+}


### PR DESCRIPTION
## Summary
- track created folder IDs to handle slug changes
- use folder ID map to set parent folder correctly
- test nested folder creation with slug changes

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab25154a6c8329839fe85407be2718