### PR TITLE
feat: preserve translated slugs

### DIFF
--- a/internal/sb/client.go
+++ b/internal/sb/client.go
@@ -63,14 +63,22 @@ func (c *Client) ListSpaces(ctx context.Context) ([]Space, error) {
 // ---------- Stories (flach) ----------
 
 type Story struct {
-	ID          int    `json:"id"`
-	Name        string `json:"name"`
-	Slug        string `json:"slug"`
-	FullSlug    string `json:"full_slug"`
-	FolderID    *int   `json:"parent_id"`
-	UpdatedAt   string `json:"updated_at"`
-	IsFolder    bool   `json:"is_folder"`
-	IsStartpage bool   `json:"is_startpage"`
+	ID              int              `json:"id"`
+	Name            string           `json:"name"`
+	Slug            string           `json:"slug"`
+	FullSlug        string           `json:"full_slug"`
+	FolderID        *int             `json:"parent_id"`
+	UpdatedAt       string           `json:"updated_at"`
+	IsFolder        bool             `json:"is_folder"`
+	IsStartpage     bool             `json:"is_startpage"`
+	TranslatedSlugs []TranslatedSlug `json:"translated_slugs,omitempty"`
+}
+
+type TranslatedSlug struct {
+	Lang     string `json:"lang"`
+	Name     string `json:"name"`
+	Slug     string `json:"slug"`
+	FullSlug string `json:"full_slug"`
 }
 
 type storiesResp struct {


### PR DESCRIPTION
## Summary
- fetch full folder details before creation to keep translated slugs
- add translated slug fields to Story model
- test folder sync with differing slug and full slug per language

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab2513ff088329989adb3819a57bf1