### PR TITLE
feat: avoid duplicate folder creation

### DIFF
--- a/internal/ui/sync.go
+++ b/internal/ui/sync.go
@@ -106,6 +106,24 @@ func (m *Model) syncStructure(st sb.Story) error {
 			parentID = &id
 			continue
 		}
+		if m.api != nil && m.targetSpace != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			existing, err := m.api.GetStoryBySlug(ctx, m.targetSpace.ID, full)
+			cancel()
+			if err != nil {
+				return err
+			}
+			if existing.ID != 0 {
+				if parentID != nil && existing.FolderID == nil {
+					id := *parentID
+					existing.FolderID = &id
+				}
+				m.storiesTarget = append(m.storiesTarget, existing)
+				id := existing.ID
+				parentID = &id
+				continue
+			}
+		}
 		src, ok := m.findSource(full)
 		if !ok {
 			src = sb.Story{Name: p, Slug: p, FullSlug: full, IsFolder: true}


### PR DESCRIPTION
## Summary
- check target space for existing folders before creating new ones
- add client support to fetch stories by slug
- test syncStructure with remote folder lookup

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ab251274f48329a0edfe72260e432f