### PR TITLE
feature/publish toggle

### DIFF
--- a/internal/sb/client.go
+++ b/internal/sb/client.go
@@ -665,6 +665,30 @@ func (c *Client) UpdateStoryRawWithPublish(ctx context.Context, spaceID int, sto
 	return resp.Story, nil
 }
 
+// UnpublishStory unpublishes a story (removes the published version)
+func (c *Client) UnpublishStory(ctx context.Context, spaceID, storyID int) error {
+	if c.token == "" {
+		return errors.New("token leer")
+	}
+	u := fmt.Sprintf(base+"/spaces/%d/stories/%d/unpublish", spaceID, storyID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", c.token)
+	req.Header.Add("Content-Type", "application/json")
+	res, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 && res.StatusCode != 204 {
+		bodyBytes, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("story.unpublish status %s: %s", res.Status, strings.TrimSpace(string(bodyBytes)))
+	}
+	return nil
+}
+
 // getStoryWithVersion fetches story with specific version parameter
 func (c *Client) getStoryWithVersion(ctx context.Context, spaceID, storyID int, version string) (Story, error) {
 	var u string

--- a/internal/sb/client.go
+++ b/internal/sb/client.go
@@ -671,7 +671,7 @@ func (c *Client) UnpublishStory(ctx context.Context, spaceID, storyID int) error
 		return errors.New("token leer")
 	}
 	u := fmt.Sprintf(base+"/spaces/%d/stories/%d/unpublish", spaceID, storyID)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/ui/handlers_preflight.go
+++ b/internal/ui/handlers_preflight.go
@@ -40,6 +40,22 @@ func (m Model) handlePreflightKey(msg tea.KeyMsg) (Model, tea.Cmd) {
 				it := m.preflight.items[idx]
 				mode := m.getPublishMode(it.Story.FullSlug)
 				if it.Story.IsFolder {
+					// If folder has no meaningful mode, try to take the first selected descendant story's mode
+					if mode == PublishModeDraft {
+						root := it.Story.FullSlug
+						for i := range m.preflight.items {
+							st := m.preflight.items[i].Story
+							if st.IsFolder {
+								continue
+							}
+							if m.preflight.items[i].Selected && !m.preflight.items[i].Skip {
+								if st.FullSlug == root || strings.HasPrefix(st.FullSlug+"/", root+"/") {
+									mode = m.getPublishMode(st.FullSlug)
+									break
+								}
+							}
+						}
+					}
 					// Apply to all descendant stories under this folder
 					root := it.Story.FullSlug
 					for i := range m.preflight.items {

--- a/internal/ui/init.go
+++ b/internal/ui/init.go
@@ -110,6 +110,10 @@ func InitialModel() Model {
 	// metrics tracking for per-item retry deltas
 	m.syncStartMetrics = make(map[int]sb.MetricsSnapshot)
 
+	// publish mode maps
+	m.publishMode = make(map[string]string)
+	m.unpublishAfter = make(map[string]bool)
+
 	return m
 }
 

--- a/internal/ui/report.go
+++ b/internal/ui/report.go
@@ -24,6 +24,8 @@ type ReportEntry struct {
 	TargetStory *sb.Story `json:"target_story,omitempty"` // Target story if created/updated
 	// Rate limit related counters (deltas captured per item)
 	RateLimit429 int `json:"rate_limit_429,omitempty"`
+	// Selected publish mode for this item (stories only): draft|publish|publish_changes
+	PublishMode string `json:"publish_mode,omitempty"`
 }
 
 // Report collects all entries and provides comprehensive sync reporting.

--- a/internal/ui/sync.go
+++ b/internal/ui/sync.go
@@ -240,7 +240,9 @@ func (m *Model) runNextItem() tea.Cmd {
 				m.unpublishAfter = make(map[string]bool)
 			}
 			m.unpublishAfter[it.Story.FullSlug] = true
+			log.Printf("UNPUBLISH_MARK: slug=%s op=update will schedule unpublish after overwrite (mode=draft, srcPub=true, tgtPub=true)", it.Story.FullSlug)
 		}
+		log.Printf("PUBLISH_OVERRIDE: slug=%s mode=%s exists=%t tgtPublished=%t publishFlag=%t", it.Story.FullSlug, mode, exists, tgtPublished, publishFlag)
 		item.overridePublish = true
 		item.publishFlag = publishFlag
 	}

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -217,4 +217,8 @@ type Model struct {
 	publishMode map[string]string // key: FullSlug
 	// Items that should be unpublished after overwrite (special case)
 	unpublishAfter map[string]bool // key: FullSlug
+
+	// --- EMA estimates for rate-limit budgeting ---
+	emaWritePerItem float64
+	emaItemDurSec   float64
 }

--- a/internal/ui/types.go
+++ b/internal/ui/types.go
@@ -211,4 +211,10 @@ type Model struct {
 	rpsGraphWidth  int
 	rpsGraphHeight int
 	showRpsGraph   bool
+
+	// --- Publish modes (UI-only) ---
+	// Per-item chosen publish mode: "draft", "publish", "publish_changes"
+	publishMode map[string]string // key: FullSlug
+	// Items that should be unpublished after overwrite (special case)
+	unpublishAfter map[string]bool // key: FullSlug
 }

--- a/internal/ui/utils.go
+++ b/internal/ui/utils.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"storyblok-sync/internal/sb"
@@ -87,6 +88,117 @@ func (m Model) hasSelectedDirectChild(slug string) bool {
 		}
 	}
 	return false
+}
+
+// --- Publish mode helpers ---
+
+const (
+	PublishModeDraft          = "draft"
+	PublishModePublish        = "publish"
+	PublishModePublishChanges = "publish_changes"
+)
+
+// getPublishMode returns the publish mode for a slug, defaulting to draft.
+func (m *Model) getPublishMode(slug string) string {
+	if m.publishMode == nil {
+		return PublishModeDraft
+	}
+	if v, ok := m.publishMode[slug]; ok && v != "" {
+		return v
+	}
+	return PublishModeDraft
+}
+
+func (m *Model) setPublishMode(slug, mode string) {
+	if m.publishMode == nil {
+		m.publishMode = make(map[string]string)
+	}
+	switch mode {
+	case PublishModeDraft, PublishModePublish, PublishModePublishChanges:
+		m.publishMode[slug] = mode
+	default:
+		m.publishMode[slug] = PublishModeDraft
+	}
+}
+
+// cyclePublishModeForSlug cycles through allowed modes for the slug, skipping invalid states.
+func (m *Model) cyclePublishModeForSlug(slug string) {
+	var it *PreflightItem
+	for i := range m.preflight.items {
+		if m.preflight.items[i].Story.FullSlug == slug {
+			it = &m.preflight.items[i]
+			break
+		}
+	}
+	if it == nil || it.Story.IsFolder {
+		return
+	}
+	curr := m.getPublishMode(slug)
+	next := func(x string) string {
+		switch x {
+		case PublishModeDraft:
+			return PublishModePublish
+		case PublishModePublish:
+			return PublishModePublishChanges
+		default:
+			return PublishModeDraft
+		}
+	}
+	for i := 0; i < 3; i++ {
+		cand := next(curr)
+		if m.isPublishModeValid(*it, cand) {
+			m.setPublishMode(slug, cand)
+			return
+		}
+		curr = cand
+	}
+	m.setPublishMode(slug, PublishModeDraft)
+}
+
+// isPublishModeValid checks if a mode is valid for the item based on existence/target state.
+func (m *Model) isPublishModeValid(it PreflightItem, mode string) bool {
+	if it.Story.IsFolder {
+		return false
+	}
+	exists, tgtPublished := false, false
+	for _, t := range m.storiesTarget {
+		if t.FullSlug == it.Story.FullSlug {
+			exists = true
+			tgtPublished = t.Published
+			break
+		}
+	}
+	switch mode {
+	case PublishModePublishChanges:
+		return exists && tgtPublished
+	case PublishModePublish, PublishModeDraft:
+		return true
+	default:
+		return false
+	}
+}
+
+// initDefaultPublishModes computes initial publish modes per item.
+func (m *Model) initDefaultPublishModes() {
+	if m.publishMode == nil {
+		m.publishMode = make(map[string]string)
+	}
+	// Default policy: mirror source state (overwrite when both published)
+	for _, it := range m.preflight.items {
+		if it.Story.IsFolder || !it.Selected || it.Skip {
+			continue
+		}
+		if it.Story.Published && m.shouldPublish() {
+			m.publishMode[it.Story.FullSlug] = PublishModePublish
+		} else {
+			m.publishMode[it.Story.FullSlug] = PublishModeDraft
+		}
+	}
+}
+
+// sortStrings is a small helper used elsewhere; keep here to avoid import churn
+func sortStrings(s []string) {
+	sort.Strings(s)
 }
 
 // selectableSpaces returns the list of spaces available for the current selection step.

--- a/internal/ui/utils.go
+++ b/internal/ui/utils.go
@@ -198,7 +198,29 @@ func (m *Model) initDefaultPublishModes() {
 
 // sortStrings is a small helper used elsewhere; keep here to avoid import churn
 func sortStrings(s []string) {
-	sort.Strings(s)
+    sort.Strings(s)
+}
+
+// expectedWriteUnits estimates write cost for scheduling budget.
+// Stories normally cost 1 write; Draft over published (overwrite+unpublish) costs 2.
+// Folders cost 1.
+func (m *Model) expectedWriteUnits(it PreflightItem) int {
+    if it.Story.IsFolder {
+        return 1
+    }
+    mode := m.getPublishMode(it.Story.FullSlug)
+    exists, tgtPublished := false, false
+    for _, t := range m.storiesTarget {
+        if t.FullSlug == it.Story.FullSlug {
+            exists = true
+            tgtPublished = t.Published
+            break
+        }
+    }
+    if mode == PublishModeDraft && it.Story.Published && exists && tgtPublished {
+        return 2
+    }
+    return 1
 }
 
 // selectableSpaces returns the list of spaces available for the current selection step.

--- a/internal/ui/view_browse.go
+++ b/internal/ui/view_browse.go
@@ -128,7 +128,12 @@ func displayStory(st sb.Story) string {
 		name = st.Slug
 	}
 	sym := storyTypeSymbol(st)
-	return fmt.Sprintf("%s %s  (%s)", sym, name, st.FullSlug)
+	// Simple source-state badge (hint only)
+	badge := "[Draft]"
+	if st.Published {
+		badge = "[Pub]"
+	}
+	return fmt.Sprintf("%s %s %s  (%s)", sym, name, helpStyle.Render(badge), st.FullSlug)
 }
 
 func storyTypeSymbol(st sb.Story) string {

--- a/internal/ui/view_sync.go
+++ b/internal/ui/view_sync.go
@@ -167,9 +167,27 @@ func (m *Model) updateSyncViewport() {
 		}
 
 		// Format: [status] Name | slug (action) [issue]
-		line := fmt.Sprintf("%s %s | %s (%s)",
+		// Badges for publish mode
+		badges := ""
+		if !item.Story.IsFolder {
+			mode := m.getPublishMode(item.Story.FullSlug)
+			switch mode {
+			case PublishModePublish:
+				badges = " [Pub]"
+			case PublishModePublishChanges:
+				badges = " [Pub+∆]"
+			default:
+				badges = " [Draft]"
+			}
+			if m.targetSpace != nil && m.targetSpace.PlanLevel == 999 {
+				badges += "[Dev]"
+			}
+		}
+
+		line := fmt.Sprintf("%s %s%s | %s (%s)",
 			color.Render(status),
 			item.Story.Name,
+			badges,
 			subtleStyle.Render(item.Story.FullSlug),
 			subtleStyle.Render(actionText))
 		if item.Issue != "" {


### PR DESCRIPTION
- **feat: implement publish toggle**
- **feat(ui,sb): add Publish/Draft/Publish+Δ toggle with badges; schedule overwrite-then-unpublish for Draft over published; add UnpublishStory (GET) with detailed logging; enrich report with publish_mode; tests for defaults, cycling, propagation, and unpublish; prepare for rate-limit optimization**
- **feat(ui): default budget to 1 when unset; add write-unit gating in scheduler; dynamic worker sizing using EMA of writes/item and item duration with 429-aware adjustments**
